### PR TITLE
Remove funny character in title

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -61,7 +61,7 @@ class KinkAgent(Agent.Movies):
         metadata.collections.add(tag.text_content().strip())
 
     # set movie title to shoot title
-    metadata.title = html.xpath('//div[@class="shoot-info"]//h1')[0].text_content() + " (" + metadata.id + ")"
+    metadata.title = html.xpath('//div[@class="shoot-info"]//h1/text()')[0] + " (" + metadata.id + ")"
 
     # set content rating to XXX
     metadata.content_rating = 'XXX'


### PR DESCRIPTION
kink.com puts a span for the favorite button into the H1 tags, which
ends up as a funny E800 character in Plex. Fix this by using text() in
the XPath expression to extract the title.